### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/colcon_build_ci.yaml
+++ b/.github/workflows/colcon_build_ci.yaml
@@ -14,6 +14,9 @@ on:
       - 'src/**'
       - '.github/workflows/colcon_build_ci.yaml'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Atlas-Racing/HydrakonSimV2/security/code-scanning/2](https://github.com/Atlas-Racing/HydrakonSimV2/security/code-scanning/2)

To fix the problem, explicitly declare a `permissions` block with least-privilege settings. This workflow only needs to read repository contents (for `actions/checkout`) and use caching; neither requires write access to the repo. The simplest and safest fix is to add `permissions: contents: read` at the workflow level so it applies to all jobs.

Concretely, in `.github/workflows/colcon_build_ci.yaml`, add a top-level `permissions:` section after the `on:` block and before `jobs:`. This will ensure that the `GITHUB_TOKEN` used by `actions/checkout@v4` and any other steps is limited to read access to repository contents, addressing the CodeQL warning without changing how the workflow behaves.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
